### PR TITLE
📚 clarify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ If an app was previously deployed with [create-react-app-buildpack](https://gith
     # You'll see "fatal: Not a git repository"; let's fix that error
     mv react-ui/.git ./
     ```
+    **Note:** If this step does not work for whatever reason, you can manually move each file (excluding the .git directory) into the `react-ui/` folder.
+1. Edit the [`react-ui/package.json`](/react-ui/package.json) file to include a proxy to the local backend server
 1. Create a root [`package.json`](package.json), [`server/`](server/), & [`.gitignore`](.gitignore) modeled after the code in this repo
 1. Commit and deploy ♻️
   


### PR DESCRIPTION
Just adding some details that might help other users overcome some minor hiccups that I encountered when migrating from create-react-app-buildpack.

* additional errors not similar to those in step 2 prevented me from successfully completing it, had to manually move all files from terminal
* not immediately clear that the front-end package.json file needs to be updated to include the proxy setting