### PR TITLE
Remove no-longer-needed install of devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "start": "node server",
-    "build": "cd react-ui/ && npm install && npm install --only=dev --no-shrinkwrap && npm run build"
+    "build": "cd react-ui/ && npm install && npm run build"
   },
   "cacheDirectories": [
     "node_modules",


### PR DESCRIPTION
Discovered by way of #35 that Create React App no longer uses devDependencies.